### PR TITLE
change unit calculation from kibi to kilo

### DIFF
--- a/pdfsam-split-by-size/src/main/java/org/pdfsam/splitbysize/SizeUnit.java
+++ b/pdfsam-split-by-size/src/main/java/org/pdfsam/splitbysize/SizeUnit.java
@@ -30,13 +30,13 @@ public enum SizeUnit {
     MEGABYTE(DefaultI18nContext.getInstance().i18n("Megabytes"), DefaultI18nContext.getInstance().i18n("MB")) {
         @Override
         public long toBytes(int raw) {
-            return KILOBYTE.toBytes(raw) * 1024;
+            return KILOBYTE.toBytes(raw) * 1000;
         }
     },
     KILOBYTE(DefaultI18nContext.getInstance().i18n("Kilobytes"), DefaultI18nContext.getInstance().i18n("KB")) {
         @Override
         public long toBytes(int raw) {
-            return raw * 1024;
+            return raw * 1000;
         }
     };
 


### PR DESCRIPTION
Change Request #ps1 - In split by size module, the created files should never exceed the specified size unless the created file contains a single page that by itself exceeds the limit size.

Issue identification - In OS (Ubuntu) size calculation is done by kilo instead of kibi. This results in size being shown greater than the specified size.

Resolution - Change size unit calculation from kibi to kilo.