### PR TITLE
take each page range input for one document as a single input

### DIFF
--- a/pdfsam-merge/src/main/java/org/pdfsam/merge/MergeParametersBuilder.java
+++ b/pdfsam-merge/src/main/java/org/pdfsam/merge/MergeParametersBuilder.java
@@ -28,6 +28,8 @@ import org.sejda.model.outline.OutlinePolicy;
 import org.sejda.model.output.FileTaskOutput;
 import org.sejda.model.parameter.MergeParameters;
 import org.sejda.model.pdf.form.AcroFormPolicy;
+import org.sejda.model.pdf.page.PageRange;
+import org.sejda.model.pdf.page.PagesSelection;
 import org.sejda.model.toc.ToCPolicy;
 
 /**
@@ -49,7 +51,16 @@ class MergeParametersBuilder extends AbstractPdfOutputParametersBuilder<MergePar
     private FileTaskOutput output;
 
     void addInput(PdfMergeInput input) {
-        this.inputs.add(input);
+        if (input.getPageSelection().size() > 0) {
+            for (PageRange sel:input.getPageSelection())
+            {
+                PdfMergeInput newInp = new PdfMergeInput(input.getSource());
+                newInp.addPageRange(sel);
+                this.inputs.add(newInp);
+            }
+        }
+        else
+            this.inputs.add(input);
     }
 
     boolean hasInput() {


### PR DESCRIPTION
Change Request #ps2 - The merge module throws an exception upon attempting to merge page ranges that intersect. Allow intersection of ranges during merging operation.

Issue identification - Sejda SDK throws an error in the case of intersecting ranges for one input source. 

Resolution - If each page range for one input source is treated as a single input, passing same source with a single page range input will overcome the intersection error.

Expected Behavior - This will result in allowing intersecting page ranges, but it will also insert duplicate pages (the intersection among ranges) in the output.