### PR TITLE
Implement combination of page range and rotation selection

### DIFF
--- a/pdfsam-rotate/pom.xml
+++ b/pdfsam-rotate/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.pdfsam</groupId>
 		<artifactId>pdfsam-parent</artifactId>
-		<version>4.1.2-SNAPSHOT</version>
+		<version>4.1.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -82,5 +82,9 @@
 			<artifactId>javafx-swing</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.sejda</groupId>
+            <artifactId>sejda-sambox</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateParametersBuilder.java
+++ b/pdfsam-rotate/src/main/java/org/pdfsam/rotate/RotateParametersBuilder.java
@@ -20,16 +20,24 @@ package org.pdfsam.rotate;
 
 import static java.util.Objects.isNull;
 
-import java.util.Set;
+import java.util.*;
 
 import org.pdfsam.support.params.AbstractPdfOutputParametersBuilder;
 import org.pdfsam.support.params.MultipleOutputTaskParametersBuilder;
 import org.pdfsam.task.BulkRotateParameters;
 import org.pdfsam.task.PdfRotationInput;
+<<<<<<< Updated upstream
 import org.sejda.commons.collection.NullSafeSet;
+=======
+import org.sejda.common.collection.NullSafeSet;
+import org.sejda.impl.sambox.component.DefaultPdfSourceOpener;
+import org.sejda.impl.sambox.component.PDDocumentHandler;
+import org.sejda.model.exception.TaskIOException;
+>>>>>>> Stashed changes
 import org.sejda.model.input.PdfSource;
 import org.sejda.model.output.SingleOrMultipleTaskOutput;
 import org.sejda.model.pdf.page.PageRange;
+import org.sejda.model.pdf.page.PagesSelection;
 import org.sejda.model.pdf.page.PredefinedSetOfPages;
 import org.sejda.model.rotation.Rotation;
 
@@ -52,7 +60,41 @@ class RotateParametersBuilder extends AbstractPdfOutputParametersBuilder<BulkRot
         if (isNull(pageSelection) || pageSelection.isEmpty()) {
             this.inputs.add(new PdfRotationInput(source, rotation, predefinedRotationType));
         } else {
-            this.inputs.add(new PdfRotationInput(source, rotation, pageSelection.stream().toArray(PageRange[]::new)));
+            this.inputs.add(new PdfRotationInput(source, rotation, getPageCombination(source,
+                    pageSelection.stream().toArray(PageRange[]::new))));
+        }
+    }
+
+    PagesSelection[] getPageCombination(PdfSource<?> source, PageRange...pages) {
+        List<PagesSelection> result = new ArrayList<>();
+        Set<Integer> pagestoRotate = new HashSet<>();
+        try {
+            PDDocumentHandler document = source.open(new DefaultPdfSourceOpener());
+            int totalPages = document.getNumberOfPages();
+            boolean selectEvenPages = predefinedRotationType.equals(PredefinedSetOfPages.EVEN_PAGES);
+            boolean selectOddPages = predefinedRotationType.equals(PredefinedSetOfPages.ODD_PAGES);
+            if (selectEvenPages || selectOddPages) {
+                for(PageRange range: pages)
+                {
+                    int rangeEnd = range.getEnd()>totalPages? totalPages:range.getEnd();
+                    for(int i = range.getStart(); i<=rangeEnd; i++)
+                    {
+                        if((selectEvenPages && i%2==0) || (selectOddPages && i%2!=0))
+                        {
+                            pagestoRotate.add(i);
+                        }
+                    }
+                }
+                for(int page: pagestoRotate){
+                    result.add(new PageRange(page,page));
+                }
+            }
+            else
+                result.addAll(Arrays.asList(pages));
+        } catch (TaskIOException e) {
+            e.printStackTrace();
+        } finally {
+            return result.toArray(PagesSelection[]::new);
         }
     }
 


### PR DESCRIPTION
Change Request #ps3 - Modify rotate feature to consider both the page-range and the even/odd/all options in conjunction when executing the job.

Issue identification - If page ranges are found as an input then the rotation type selection is ignored.

Resolution - For page range selection input select the pages according to rotation type and pass those as input parameters to Sejda SDK

Expected Behavior - This will result in allowing page range selection as well as even/odd/all type selection for the page ranges.